### PR TITLE
Fix duplicate loading of method_decorators/version

### DIFF
--- a/method_decorators.gemspec
+++ b/method_decorators.gemspec
@@ -1,5 +1,7 @@
 # -*- encoding: utf-8 -*-
-require File.expand_path('../lib/method_decorators/version', __FILE__)
+lib_dir = File.expand_path('lib', File.dirname(__FILE__))
+$LOAD_PATH.unshift(lib_dir) unless $LOAD_PATH.include?(lib_dir)
+require 'method_decorators/version'
 
 Gem::Specification.new do |gem|
   gem.authors       = ["Michael Fairley"]


### PR DESCRIPTION
The lib/method_decorators/version.rb file was being loaded twice when
running RSpec with bundler because method_decorators.gemspec and
lib/method_decorators.rb required it in 2 different ways.
