### PR TITLE
Change require statement in decorators.rb

### DIFF
--- a/lib/method_decorators/decorators.rb
+++ b/lib/method_decorators/decorators.rb
@@ -1,1 +1,3 @@
-Dir[File.dirname(__FILE__) + '/decorators/*.rb'].each {|file| require file }
+Dir.glob(File.dirname(__FILE__) + '/decorators/*.rb') do |file|
+  require "method_decorators/decorators/#{File.basename(file, '.rb')}"
+end


### PR DESCRIPTION
This helps prevent loading files twice. Instead of requiring the full
path to the file, it requires
'method_decorators/decorators/name_of_decorator'.
