### PR TITLE
Fix deprecated_spec.rb

### DIFF
--- a/spec/decorators/deprecated_spec.rb
+++ b/spec/decorators/deprecated_spec.rb
@@ -53,6 +53,10 @@ describe MethodDecorators::Deprecated do
       $stderr.rewind
     end
 
+    after do
+      $stderr = STDERR
+    end
+
     let(:klass) {
       Class.new Base do
         +MethodDecorators::Deprecated


### PR DESCRIPTION
Rename spec/decorators/deprecated.rb to spec/decorators/deprecated_spec.rb (so bundle exec rspec runs this).

Restore $stderr in deprecated_spec.rb.
